### PR TITLE
Fix header ext data length calculation in rtpdec.c

### DIFF
--- a/libavformat/rtpdec.c
+++ b/libavformat/rtpdec.c
@@ -640,6 +640,9 @@ static int rtp_parse_packet_internal(RTPDemuxContext *s, AVPacket *pkt,
         /* calculate the header extension length (stored as number
          * of 32-bit words) */
         extlen = (AV_RB16(buf + 2) + 1) << 2;
+	/* should also take the four-octet extension header into
+	 * account */     
+	extlen += 4;    
 
         if (len < extlen)
             return -1;

--- a/libavformat/rtpdec.c
+++ b/libavformat/rtpdec.c
@@ -640,9 +640,9 @@ static int rtp_parse_packet_internal(RTPDemuxContext *s, AVPacket *pkt,
         /* calculate the header extension length (stored as number
          * of 32-bit words) */
         extlen = (AV_RB16(buf + 2) + 1) << 2;
-	/* should also take the four-octet extension header into
-	 * account */     
-	extlen += 4;    
+        /* should also take the four-octet extension header into
+         * account */     
+        extlen += 4;    
 
         if (len < extlen)
             return -1;


### PR DESCRIPTION
when calculating the data length of header extension data in RTP packet, we should take the four-octet extension header into account.